### PR TITLE
Allow individual rules to have configuration

### DIFF
--- a/xiblint/__main__.py
+++ b/xiblint/__main__.py
@@ -77,9 +77,9 @@ def main():
 
 def process_file(file_path, checkers):
     context = XibContext(file_path)
-    for rule_name, checker in checkers.items():
+    for rule_name, (checker, config) in checkers.items():
         context.rule_name = rule_name
-        checker(context)
+        checker(config, context)
     return context.errors
 
 

--- a/xiblint/config.py
+++ b/xiblint/config.py
@@ -18,11 +18,12 @@ class Config(object):
         with open(self.filename, 'r') as file:
             data = json.load(file)
         self.rules = data.get('rules', [])
+        self.rules_config = data.get('rules_config', {})
         validate_rule_patterns(self.rules)
         self.include_paths = data.get('include_paths', [u'.'])
-        self.paths = {abspath(path): PathConfig(self.rules, config)
+        self.paths = {abspath(path): PathConfig(self.rules, self.rules_config, config)
                       for (path, config) in data.get('paths', {}).items()}
-        self.base_config = PathConfig(self.rules, {})
+        self.base_config = PathConfig(self.rules, self.rules_config, {})
 
     def _config_for_file_path(self, file_path):
         file_path = abspath(file_path)
@@ -38,7 +39,7 @@ class Config(object):
 
 
 class PathConfig(object):
-    def __init__(self, default_rules, data):
+    def __init__(self, default_rules, rules_config, data):
         self.path_rules = data.get('rules')
         validate_rule_patterns(self.path_rules)
         self.excluded_rules = data.get('excluded_rules', [])
@@ -46,9 +47,11 @@ class PathConfig(object):
 
         # Filter checkers
         patterns = self.path_rules if self.path_rules is not None else default_rules
+        rules_config = data.get('rules_config') or rules_config
         excluded_patterns = self.excluded_rules
         self.checkers = {
-            rule: checker for (rule, checker) in xiblint.rules.rule_checkers.items()
+            rule: (checker, rules_config.get(rule))
+            for (rule, checker) in xiblint.rules.rule_checkers.items()
             if any(fnmatch(rule, pattern) for pattern in patterns) and
             not any(fnmatch(rule, pattern) for pattern in excluded_patterns)
         }

--- a/xiblint/config.py
+++ b/xiblint/config.py
@@ -20,9 +20,9 @@ class Config(object):
         self.rules = data.get('rules', [])
         validate_rule_patterns(self.rules)
         self.include_paths = data.get('include_paths', [u'.'])
-        self.paths = {abspath(path): PathConfig(self, config)
+        self.paths = {abspath(path): PathConfig(self.rules, config)
                       for (path, config) in data.get('paths', {}).items()}
-        self.base_config = PathConfig(self, {})
+        self.base_config = PathConfig(self.rules, {})
 
     def _config_for_file_path(self, file_path):
         file_path = abspath(file_path)
@@ -38,15 +38,14 @@ class Config(object):
 
 
 class PathConfig(object):
-    def __init__(self, config, data):
-        self.config = config
+    def __init__(self, default_rules, data):
         self.path_rules = data.get('rules')
         validate_rule_patterns(self.path_rules)
         self.excluded_rules = data.get('excluded_rules', [])
         validate_rule_patterns(self.excluded_rules)
 
         # Filter checkers
-        patterns = self.path_rules if self.path_rules is not None else self.config.rules
+        patterns = self.path_rules if self.path_rules is not None else default_rules
         excluded_patterns = self.excluded_rules
         self.checkers = {
             rule: checker for (rule, checker) in xiblint.rules.rule_checkers.items()

--- a/xiblint/rules/accessibility_format.py
+++ b/xiblint/rules/accessibility_format.py
@@ -10,7 +10,7 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     views_with_accessibility_format = {
         element.parent.parent
         for element in context.tree.findall(

--- a/xiblint/rules/accessibility_labels_for_image_buttons.py
+++ b/xiblint/rules/accessibility_labels_for_image_buttons.py
@@ -9,7 +9,7 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for button in context.tree.findall(".//button"):
         state_normal = button.find("./state[@key='normal']")
         if (

--- a/xiblint/rules/accessibility_labels_for_images.py
+++ b/xiblint/rules/accessibility_labels_for_images.py
@@ -9,7 +9,7 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for image_view in context.tree.findall(".//imageView"):
         if (
             view_is_accessibility_element(image_view) is True and

--- a/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
+++ b/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
@@ -9,7 +9,7 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for element in context.tree.findall(".//textField") + context.tree.findall(".//textView"):
         placeholder = (element.get('placeholder') if element.tag == 'textField'
                        else get_view_user_defined_attr(element, 'placeholder'))

--- a/xiblint/rules/autolayout_frames.py
+++ b/xiblint/rules/autolayout_frames.py
@@ -3,7 +3,7 @@ Checks for ambiguous and misplaced views.
 """
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for element in context.tree.iter():
         if element.get('ambiguous') == 'YES':
             context.error(element, "View with ambiguous constraints")

--- a/xiblint/rules/automation_identifiers.py
+++ b/xiblint/rules/automation_identifiers.py
@@ -3,7 +3,7 @@ Makes sure that interactive views have accessibility identifiers, to support tes
 """
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for tag in ['button', 'textField', 'textView']:
         for view in context.tree.findall(".//{}".format(tag)):
             if view.find('./accessibility[@identifier]') is None:

--- a/xiblint/rules/automation_identifiers_for_outlet_labels.py
+++ b/xiblint/rules/automation_identifiers_for_outlet_labels.py
@@ -4,7 +4,7 @@ Labels with outlets might get dynamic text, and therefore should be accessible t
 """
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     for outlet in context.tree.findall(".//viewController/connections/outlet"):
         destination = outlet.get('destination')
         label = context.tree.find(".//label[@id='{}']".format(destination))

--- a/xiblint/rules/no_simulated_metrics.py
+++ b/xiblint/rules/no_simulated_metrics.py
@@ -3,7 +3,7 @@ Ensures there are no `simulatedMetricsContainer`s, which were removed with Xcode
 """
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     root = context.tree.getroot()
     for container in root.findall('.//simulatedMetricsContainer'):
         context.error(container, 'SimulatedMetricsContainers should be removed (resave with Xcode 9+)')

--- a/xiblint/rules/no_trait_variations.py
+++ b/xiblint/rules/no_trait_variations.py
@@ -3,7 +3,7 @@ Checks for Trait Variations being enabled.
 """
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     root = context.tree.getroot()
     if root.get('useTraitCollections') == 'YES' and root.get('targetRuntime') != 'watchKit':
         context.error(root, "Document has 'Use Trait Variations' enabled")

--- a/xiblint/rules/simulated_metrics_retina4_0.py
+++ b/xiblint/rules/simulated_metrics_retina4_0.py
@@ -8,7 +8,7 @@ ALLOWED_DEVICES = [
 ]
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+def check(_, context):  # type: (Dict[str, Any], xiblint.xibcontext.XibContext) -> None
     root = context.tree.getroot()
 
     # In Xcode 9 this metadata is in a new place


### PR DESCRIPTION
This allows you to define configuration per rule:

```json
{
  "rules": [
    "autolayout_frames",
  ],
  "rules_config": {
    "autolayout_frames": {
      "some custom config": {}
    }
  }
}
```

This will be useful for rules where you want to allow some set of values to be valid, that aren't particularly generic. Like what custom fonts are valid for your project