### PR TITLE
Allow individual rules to have configuration

### DIFF
--- a/xiblint/__main__.py
+++ b/xiblint/__main__.py
@@ -58,15 +58,13 @@ def main():
     include_paths = args.paths or config.include_paths
     for path in include_paths:
         if os.path.isfile(path):
-            checkers = config.checkers(path)
-            errors += process_file(path, checkers)
+            errors += process_file(path, config)
         elif os.path.isdir(path):
             for root, _, files in os.walk(path):
                 for filename in files:
                     if os.path.splitext(filename)[1].lower() in ('.storyboard', '.xib'):
                         file_path = os.path.join(root, filename)
-                        checkers = config.checkers(file_path)
-                        errors += process_file(file_path, checkers)
+                        errors += process_file(file_path, config)
         else:
             print("Error: Invalid path '{}'".format(path))
             sys.exit(1)
@@ -76,11 +74,14 @@ def main():
     sys.exit(1 if errors else 0)
 
 
-def process_file(file_path, checkers):
+def process_file(file_path, config):
+    checkers = config.checkers(file_path)
     context = XibContext(file_path)
-    for rule_name, checker in checkers.items():
+    for rule_name, klass in checkers.items():
         context.rule_name = rule_name
-        checker(context)
+        rule_config = config.config_for_rule(file_path, rule_name)
+        instance = klass(rule_config)
+        instance.check(context)
     return context.errors
 
 

--- a/xiblint/config.py
+++ b/xiblint/config.py
@@ -19,10 +19,13 @@ class Config(object):
             data = json.load(f)
         self.rules = data.get('rules', [])
         validate_rule_patterns(self.rules)
+        default_rules_config = data.get('rules_config', {})
         self.include_paths = data.get('include_paths', [u'.'])
-        self.paths = {abspath(path): PathConfig(self, config)
-                      for (path, config) in data.get('paths', {}).items()}
-        self.base_config = PathConfig(self, {})
+        self.paths = {
+            abspath(path): PathConfig(self, default_rules_config, config)
+            for (path, config) in data.get('paths', {}).items()
+        }
+        self.base_config = PathConfig(self, default_rules_config, {})
 
     def _config_for_file_path(self, file_path):
         file_path = abspath(file_path)
@@ -36,20 +39,28 @@ class Config(object):
     def checkers(self, file_path):
         return self._config_for_file_path(file_path).checkers
 
+    def config_for_rule(self, file_path, rule_name):
+        return self._config_for_file_path(file_path).config_for_rule(rule_name)
+
 
 class PathConfig(object):
-    def __init__(self, config, data):
+    def __init__(self, config, default_rules_config, data):
         self.config = config
         self.path_rules = data.get('rules')
         validate_rule_patterns(self.path_rules)
         self.excluded_rules = data.get('excluded_rules', [])
         validate_rule_patterns(self.excluded_rules)
+        self._rules_config = (data.get('rules_config', {}) or
+                              default_rules_config)
 
         # Filter checkers
         patterns = self.path_rules if self.path_rules is not None else self.config.rules
         excluded_patterns = self.excluded_rules
         self.checkers = {
-            rule: checker for (rule, checker) in xiblint.rules.rule_checkers.items()
+            rule: klass for (rule, klass) in xiblint.rules.rule_checkers.items()
             if any(fnmatch(rule, pattern) for pattern in patterns) and
             not any(fnmatch(rule, pattern) for pattern in excluded_patterns)
         }
+
+    def config_for_rule(self, rule_name):
+        return self._rules_config.get(rule_name, {})

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -8,8 +8,7 @@ class Rule(object):
     def __init__(self, config):
         self.config = config
 
-    @staticmethod
-    def check(_):
+    def check(self, context):
         raise NotImplementedError()
 
 

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -13,8 +13,7 @@ class Rule(object):
 
 
 def _class_name_for_file(filename):
-    components = filename.split("_")
-    return "".join(x.title() for x in components)
+    return filename.title().replace("_", "")
 
 
 def _collect_checkers():

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -4,14 +4,20 @@ from os.path import basename, dirname
 from importlib import import_module
 
 
+def _class_name_for_file(filename):
+    components = filename.split("_")
+    return "".join(x.title() for x in components)
+
+
 def _collect_checkers():
     _rule_checkers = {}
     for filepath in glob(dirname(__file__) + "/*.py"):
         rule_name = basename(filepath)[:-3]
         module = import_module('xiblint.rules.' + rule_name)
-        check = getattr(module, 'check', None)
-        if inspect.isfunction(check):
-            _rule_checkers[rule_name] = check
+        class_name = _class_name_for_file(rule_name)
+        klass = getattr(module, class_name, None)
+        if inspect.isclass(klass):
+            _rule_checkers[rule_name] = klass
     return _rule_checkers
 
 rule_checkers = _collect_checkers()

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -4,6 +4,11 @@ from os.path import basename, dirname
 from importlib import import_module
 
 
+class Rule(object):
+    def __init__(self, config):
+        pass
+
+
 def _class_name_for_file(filename):
     components = filename.split("_")
     return "".join(x.title() for x in components)

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -6,7 +6,11 @@ from importlib import import_module
 
 class Rule(object):
     def __init__(self, config):
-        pass
+        self.config = config
+
+    @staticmethod
+    def check(_):
+        raise Exception("Implement this in your subclass")
 
 
 def _class_name_for_file(filename):

--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -10,7 +10,7 @@ class Rule(object):
 
     @staticmethod
     def check(_):
-        raise Exception("Implement this in your subclass")
+        raise NotImplementedError()
 
 
 def _class_name_for_file(filename):

--- a/xiblint/rules/accessibility_format.py
+++ b/xiblint/rules/accessibility_format.py
@@ -3,6 +3,7 @@ Checks for incorrect use of Lyft extensions `accessibilityFormat` and `accessibi
 """
 import re
 
+from xiblint.rules import Rule
 from xiblint.xibutils import (
     get_object_id,
     get_view_user_defined_attr,
@@ -10,10 +11,7 @@ from xiblint.xibutils import (
 )
 
 
-class AccessibilityFormat(object):
-    def __init__(self, _):
-        pass
-
+class AccessibilityFormat(Rule):
     @staticmethod
     def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
         views_with_accessibility_format = {

--- a/xiblint/rules/accessibility_format.py
+++ b/xiblint/rules/accessibility_format.py
@@ -12,8 +12,7 @@ from xiblint.xibutils import (
 
 
 class AccessibilityFormat(Rule):
-    @staticmethod
-    def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         views_with_accessibility_format = {
             element.parent.parent
             for element in context.tree.findall(

--- a/xiblint/rules/accessibility_format.py
+++ b/xiblint/rules/accessibility_format.py
@@ -10,19 +10,24 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    views_with_accessibility_format = {
-        element.parent.parent
-        for element in context.tree.findall(
-            ".//userDefinedRuntimeAttributes/userDefinedRuntimeAttribute[@keyPath='accessibilityFormat']")
-    }
-    views_with_accessibility_sources = {
-        element.parent.parent
-        for element in context.tree.findall(".//connections/outletCollection[@property='accessibilitySources']")
-    }
+class AccessibilityFormat(object):
+    def __init__(self, _):
+        pass
 
-    for view in views_with_accessibility_format | views_with_accessibility_sources:
-        check_view(context, view)
+    @staticmethod
+    def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
+        views_with_accessibility_format = {
+            element.parent.parent
+            for element in context.tree.findall(
+                ".//userDefinedRuntimeAttributes/userDefinedRuntimeAttribute[@keyPath='accessibilityFormat']")
+        }
+        views_with_accessibility_sources = {
+            element.parent.parent
+            for element in context.tree.findall(".//connections/outletCollection[@property='accessibilitySources']")
+        }
+
+        for view in views_with_accessibility_format | views_with_accessibility_sources:
+            check_view(context, view)
 
 
 def check_view(context, view):

--- a/xiblint/rules/accessibility_labels_for_image_buttons.py
+++ b/xiblint/rules/accessibility_labels_for_image_buttons.py
@@ -2,6 +2,8 @@
 Checks for image buttons with no accessibility label.
 In this case, VoiceOver will announce the image asset's name, which might be unwanted.
 """
+
+from xiblint.rules import Rule
 from xiblint.xibutils import (
     view_is_accessibility_element,
     view_accessibility_label,
@@ -9,26 +11,29 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for button in context.tree.findall(".//button"):
-        state_normal = button.find("./state[@key='normal']")
-        if (
-                state_normal is None or
-                'title' in state_normal.attrib or
-                view_is_accessibility_element(button) is False or
-                view_accessibility_label(button) or
-                get_view_user_defined_attr(button, 'accessibilityFormat')
-        ):
-            continue
+class AccessibilityLabelsForImageButtons(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for button in context.tree.findall(".//button"):
+            state_normal = button.find("./state[@key='normal']")
+            if (
+                    state_normal is None or
+                    'title' in state_normal.attrib or
+                    view_is_accessibility_element(button) is False or
+                    view_accessibility_label(button) or
+                    get_view_user_defined_attr(button, 'accessibilityFormat')
+            ):
+                continue
 
-        if 'image' in state_normal.attrib:
-            context.error(button,
-                          "Button with image '{}' and no title; "
-                          "should either have an accessibility label or 'Accessibility Enabled' unchecked",
-                          state_normal.attrib['image'])
+            if 'image' in state_normal.attrib:
+                context.error(
+                    button,
+                    "Button with image '{}' and no title; "
+                    "should either have an accessibility label or 'Accessibility Enabled' unchecked",
+                    state_normal.attrib['image'])
 
-        if 'backgroundImage' in state_normal.attrib:
-            context.error(button,
-                          "Button with background image '{}' and no title "
-                          "should either have an accessibility label or 'Accessibility Enabled' unchecked",
-                          state_normal.attrib['backgroundImage'])
+            if 'backgroundImage' in state_normal.attrib:
+                context.error(
+                    button,
+                    "Button with background image '{}' and no title "
+                    "should either have an accessibility label or 'Accessibility Enabled' unchecked",
+                    state_normal.attrib['backgroundImage'])

--- a/xiblint/rules/accessibility_labels_for_images.py
+++ b/xiblint/rules/accessibility_labels_for_images.py
@@ -2,6 +2,7 @@
 Checks for accessible images with no accessibility label.
 In this case, VoiceOver will announce the image asset's name, which might be unwanted.
 """
+from xiblint.rules import Rule
 from xiblint.xibutils import (
     view_is_accessibility_element,
     view_accessibility_label,
@@ -9,11 +10,12 @@ from xiblint.xibutils import (
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for image_view in context.tree.findall(".//imageView"):
-        if (
-                view_is_accessibility_element(image_view) is True and
-                not view_accessibility_label(image_view) and
-                not get_view_user_defined_attr(image_view, 'accessibilityFormat')
-        ):
-            context.error(image_view, "Image is accessible but has no accessibility label")
+class AccessibilityLabelsForImages(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for image_view in context.tree.findall(".//imageView"):
+            if (
+                    view_is_accessibility_element(image_view) is True and
+                    not view_accessibility_label(image_view) and
+                    not get_view_user_defined_attr(image_view, 'accessibilityFormat')
+            ):
+                context.error(image_view, "Image is accessible but has no accessibility label")

--- a/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
+++ b/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
@@ -3,22 +3,24 @@ Checks for text fields and text views with a placeholder and no accessibility la
 A placeholder is not a substitute for an accessibility label, since it's no longer announced
 after the text is edited.
 """
+from xiblint.rules import Rule
 from xiblint.xibutils import (
     get_view_user_defined_attr,
     view_is_accessibility_element,
 )
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for element in context.tree.findall(".//textField") + context.tree.findall(".//textView"):
-        placeholder = (element.get('placeholder') if element.tag == 'textField'
-                       else get_view_user_defined_attr(element, 'placeholder'))
-        if (
-                placeholder is not None and
-                element.find('./accessibility[@label]') is None and
-                view_is_accessibility_element(element) is not False
-        ):
-            context.error(element,
-                          "{} with placeholder text '{}' but no accessibility label",
-                          element.tag,
-                          element.get('placeholder'))
+class AccessibilityLabelsForTextWithPlaceholder(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for element in context.tree.findall(".//textField") + context.tree.findall(".//textView"):
+            placeholder = (element.get('placeholder') if element.tag == 'textField'
+                           else get_view_user_defined_attr(element, 'placeholder'))
+            if (
+                    placeholder is not None and
+                    element.find('./accessibility[@label]') is None and
+                    view_is_accessibility_element(element) is not False
+            ):
+                context.error(
+                    element,
+                    "{} with placeholder text '{}' but no accessibility label",
+                    element.tag, element.get('placeholder'))

--- a/xiblint/rules/autolayout_frames.py
+++ b/xiblint/rules/autolayout_frames.py
@@ -2,10 +2,13 @@
 Checks for ambiguous and misplaced views.
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for element in context.tree.iter():
-        if element.get('ambiguous') == 'YES':
-            context.error(element, "View with ambiguous constraints")
-        elif element.get('misplaced') == 'YES':
-            context.error(element, "Misplaced view")
+
+class AutolayoutFrames(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for element in context.tree.iter():
+            if element.get('ambiguous') == 'YES':
+                context.error(element, "View with ambiguous constraints")
+            elif element.get('misplaced') == 'YES':
+                context.error(element, "Misplaced view")

--- a/xiblint/rules/automation_identifiers.py
+++ b/xiblint/rules/automation_identifiers.py
@@ -2,9 +2,12 @@
 Makes sure that interactive views have accessibility identifiers, to support testing through UI Automation.
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for tag in ['button', 'textField', 'textView']:
-        for view in context.tree.findall(".//{}".format(tag)):
-            if view.find('./accessibility[@identifier]') is None:
-                context.error(view, "{} requires an accessibility identifier for UI Automation", tag)
+
+class AutomationIdentifiers(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for tag in ['button', 'textField', 'textView']:
+            for view in context.tree.findall(".//{}".format(tag)):
+                if view.find('./accessibility[@identifier]') is None:
+                    context.error(view, "{} requires an accessibility identifier for UI Automation", tag)

--- a/xiblint/rules/automation_identifiers_for_outlet_labels.py
+++ b/xiblint/rules/automation_identifiers_for_outlet_labels.py
@@ -3,17 +3,20 @@ Checks for labels with outlets into a view controller that have no accessibility
 Labels with outlets might get dynamic text, and therefore should be accessible to UI testing.
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for outlet in context.tree.findall(".//viewController/connections/outlet"):
-        destination = outlet.get('destination')
-        label = context.tree.find(".//label[@id='{}']".format(destination))
-        if label is None:
-            continue
-        if label.find('./accessibility[@identifier]') is not None:
-            continue
-        context.error(label,
-                      "Label with text '{}' has an outlet into the view controller "
-                      "so it requires an accessibility identifier",
-                      label.get('text'),
-                      label.tag)
+
+class AutomationIdentifiersForOutletLabels(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for outlet in context.tree.findall(".//viewController/connections/outlet"):
+            destination = outlet.get('destination')
+            label = context.tree.find(".//label[@id='{}']".format(destination))
+            if label is None:
+                continue
+            if label.find('./accessibility[@identifier]') is not None:
+                continue
+            context.error(
+                label,
+                "Label with text '{}' has an outlet into the view controller "
+                "so it requires an accessibility identifier",
+                label.get('text'), label.tag)

--- a/xiblint/rules/no_simulated_metrics.py
+++ b/xiblint/rules/no_simulated_metrics.py
@@ -2,8 +2,11 @@
 Ensures there are no `simulatedMetricsContainer`s, which were removed with Xcode 9
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    root = context.tree.getroot()
-    for container in root.findall('.//simulatedMetricsContainer'):
-        context.error(container, 'SimulatedMetricsContainers should be removed (resave with Xcode 9+)')
+
+class NoSimulatedMetrics(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        root = context.tree.getroot()
+        for container in root.findall('.//simulatedMetricsContainer'):
+            context.error(container, 'SimulatedMetricsContainers should be removed (resave with Xcode 9+)')

--- a/xiblint/rules/no_trait_variations.py
+++ b/xiblint/rules/no_trait_variations.py
@@ -2,8 +2,11 @@
 Checks for Trait Variations being enabled.
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    root = context.tree.getroot()
-    if root.get('useTraitCollections') == 'YES' and root.get('targetRuntime') != 'watchKit':
-        context.error(root, "Document has 'Use Trait Variations' enabled")
+
+class NoTraitVariations(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        root = context.tree.getroot()
+        if root.get('useTraitCollections') == 'YES' and root.get('targetRuntime') != 'watchKit':
+            context.error(root, "Document has 'Use Trait Variations' enabled")

--- a/xiblint/rules/no_view_controller_links_to_other_bundles.py
+++ b/xiblint/rules/no_view_controller_links_to_other_bundles.py
@@ -2,8 +2,11 @@
 Ensures there are no links to storyboards in different bundles
 """
 
+from xiblint.rules import Rule
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    for element in context.tree.findall(".//viewControllerPlaceholder"):
-        if element.get("bundleIdentifier"):
-            context.error(element, "Linking to a view controller in another bundle")
+
+class NoViewControllerLinksToOtherBundles(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        for element in context.tree.findall(".//viewControllerPlaceholder"):
+            if element.get("bundleIdentifier"):
+                context.error(element, "Linking to a view controller in another bundle")

--- a/xiblint/rules/simulated_metrics_retina4_0.py
+++ b/xiblint/rules/simulated_metrics_retina4_0.py
@@ -2,16 +2,22 @@
 Ensures simulated metrics are for the iPhone SE or a 38mm watch, which are currently the smallest display profiles.
 """
 
+from xiblint.rules import Rule
+
 ALLOWED_DEVICES = [
     'retina4_0',
     'watch38',
 ]
 
 
-def check(context):  # type: (xiblint.xibcontext.XibContext) -> None
-    root = context.tree.getroot()
+class SimulatedMetricsRetina40(Rule):
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        root = context.tree.getroot()
 
-    # In Xcode 9 this metadata is in a new place
-    device = root.find('device')
-    if device is not None and device.get('id') not in ALLOWED_DEVICES:
-        context.error(device, 'Simulated metrics ("View As:") must be one of: {}'.format(', '.join(ALLOWED_DEVICES)))
+        # In Xcode 9 this metadata is in a new place
+        device = root.find('device')
+        if device is not None and device.get('id') not in ALLOWED_DEVICES:
+            context.error(
+                device,
+                'Simulated metrics ("View As:") must be one of: {}'
+                .format(', '.join(ALLOWED_DEVICES)))


### PR DESCRIPTION
This allows you to define configuration per rule:

```json
{
  "rules": [
    "autolayout_frames",
  ],
  "rules_config": {
    "autolayout_frames": {
      "some custom config": {}
    }
  }
}
```

This will be useful for rules where you want to allow some set of values to be valid, that aren't particularly generic. Like what custom fonts are valid for your project