### PR TITLE
Move rule documentation to classes

### DIFF
--- a/xiblint/__main__.py
+++ b/xiblint/__main__.py
@@ -17,10 +17,10 @@ def make_epilog_text():
     for rule_name in sorted(xiblint.rules.rule_checkers.keys()):
         checker = xiblint.rules.rule_checkers[rule_name]
         description += "\t{}\n".format(rule_name)
-        doc = sys.modules[checker.__module__].__doc__
+        doc = checker.__doc__
         if doc is not None:
             for line in doc.strip().split("\n"):
-                description += " " * 24 + "{}\n".format(line)
+                description += " " * 24 + "{}\n".format(line.strip())
 
     return description
 

--- a/xiblint/rules/accessibility_format.py
+++ b/xiblint/rules/accessibility_format.py
@@ -1,6 +1,3 @@
-"""
-Checks for incorrect use of Lyft extensions `accessibilityFormat` and `accessibilitySources`.
-"""
 import re
 
 from xiblint.rules import Rule
@@ -12,6 +9,9 @@ from xiblint.xibutils import (
 
 
 class AccessibilityFormat(Rule):
+    """
+    Checks for incorrect use of Lyft extensions `accessibilityFormat` and `accessibilitySources`.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         views_with_accessibility_format = {
             element.parent.parent

--- a/xiblint/rules/accessibility_labels_for_image_buttons.py
+++ b/xiblint/rules/accessibility_labels_for_image_buttons.py
@@ -1,8 +1,3 @@
-"""
-Checks for image buttons with no accessibility label.
-In this case, VoiceOver will announce the image asset's name, which might be unwanted.
-"""
-
 from xiblint.rules import Rule
 from xiblint.xibutils import (
     view_is_accessibility_element,
@@ -12,6 +7,10 @@ from xiblint.xibutils import (
 
 
 class AccessibilityLabelsForImageButtons(Rule):
+    """
+    Checks for image buttons with no accessibility label.
+    In this case, VoiceOver will announce the image asset's name, which might be unwanted.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for button in context.tree.findall(".//button"):
             state_normal = button.find("./state[@key='normal']")

--- a/xiblint/rules/accessibility_labels_for_images.py
+++ b/xiblint/rules/accessibility_labels_for_images.py
@@ -1,7 +1,3 @@
-"""
-Checks for accessible images with no accessibility label.
-In this case, VoiceOver will announce the image asset's name, which might be unwanted.
-"""
 from xiblint.rules import Rule
 from xiblint.xibutils import (
     view_is_accessibility_element,
@@ -11,6 +7,10 @@ from xiblint.xibutils import (
 
 
 class AccessibilityLabelsForImages(Rule):
+    """
+    Checks for accessible images with no accessibility label.
+    In this case, VoiceOver will announce the image asset's name, which might be unwanted.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for image_view in context.tree.findall(".//imageView"):
             if (

--- a/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
+++ b/xiblint/rules/accessibility_labels_for_text_with_placeholder.py
@@ -1,8 +1,3 @@
-"""
-Checks for text fields and text views with a placeholder and no accessibility label.
-A placeholder is not a substitute for an accessibility label, since it's no longer announced
-after the text is edited.
-"""
 from xiblint.rules import Rule
 from xiblint.xibutils import (
     get_view_user_defined_attr,
@@ -11,6 +6,11 @@ from xiblint.xibutils import (
 
 
 class AccessibilityLabelsForTextWithPlaceholder(Rule):
+    """
+    Checks for text fields and text views with a placeholder and no accessibility label.
+    A placeholder is not a substitute for an accessibility label, since it's no longer announced
+    after the text is edited.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for element in context.tree.findall(".//textField") + context.tree.findall(".//textView"):
             placeholder = (element.get('placeholder') if element.tag == 'textField'

--- a/xiblint/rules/autolayout_frames.py
+++ b/xiblint/rules/autolayout_frames.py
@@ -1,11 +1,10 @@
-"""
-Checks for ambiguous and misplaced views.
-"""
-
 from xiblint.rules import Rule
 
 
 class AutolayoutFrames(Rule):
+    """
+    Checks for ambiguous and misplaced views.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for element in context.tree.iter():
             if element.get('ambiguous') == 'YES':

--- a/xiblint/rules/automation_identifiers.py
+++ b/xiblint/rules/automation_identifiers.py
@@ -1,11 +1,10 @@
-"""
-Makes sure that interactive views have accessibility identifiers, to support testing through UI Automation.
-"""
-
 from xiblint.rules import Rule
 
 
 class AutomationIdentifiers(Rule):
+    """
+    Makes sure that interactive views have accessibility identifiers, to support testing through UI Automation.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for tag in ['button', 'textField', 'textView']:
             for view in context.tree.findall(".//{}".format(tag)):

--- a/xiblint/rules/automation_identifiers_for_outlet_labels.py
+++ b/xiblint/rules/automation_identifiers_for_outlet_labels.py
@@ -1,12 +1,11 @@
-"""
-Checks for labels with outlets into a view controller that have no accessibility identifiers.
-Labels with outlets might get dynamic text, and therefore should be accessible to UI testing.
-"""
-
 from xiblint.rules import Rule
 
 
 class AutomationIdentifiersForOutletLabels(Rule):
+    """
+    Checks for labels with outlets into a view controller that have no accessibility identifiers.
+    Labels with outlets might get dynamic text, and therefore should be accessible to UI testing.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for outlet in context.tree.findall(".//viewController/connections/outlet"):
             destination = outlet.get('destination')

--- a/xiblint/rules/no_simulated_metrics.py
+++ b/xiblint/rules/no_simulated_metrics.py
@@ -1,11 +1,10 @@
-"""
-Ensures there are no `simulatedMetricsContainer`s, which were removed with Xcode 9
-"""
-
 from xiblint.rules import Rule
 
 
 class NoSimulatedMetrics(Rule):
+    """
+    Ensures there are no `simulatedMetricsContainer`s, which were removed with Xcode 9
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         root = context.tree.getroot()
         for container in root.findall('.//simulatedMetricsContainer'):

--- a/xiblint/rules/no_trait_variations.py
+++ b/xiblint/rules/no_trait_variations.py
@@ -1,11 +1,10 @@
-"""
-Checks for Trait Variations being enabled.
-"""
-
 from xiblint.rules import Rule
 
 
 class NoTraitVariations(Rule):
+    """
+    Checks for Trait Variations being enabled.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         root = context.tree.getroot()
         if root.get('useTraitCollections') == 'YES' and root.get('targetRuntime') != 'watchKit':

--- a/xiblint/rules/no_view_controller_links_to_other_bundles.py
+++ b/xiblint/rules/no_view_controller_links_to_other_bundles.py
@@ -1,11 +1,10 @@
-"""
-Ensures there are no links to storyboards in different bundles
-"""
-
 from xiblint.rules import Rule
 
 
 class NoViewControllerLinksToOtherBundles(Rule):
+    """
+    Ensures there are no links to storyboards in different bundles
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         for element in context.tree.findall(".//viewControllerPlaceholder"):
             if element.get("bundleIdentifier"):

--- a/xiblint/rules/simulated_metrics_retina4_0.py
+++ b/xiblint/rules/simulated_metrics_retina4_0.py
@@ -1,7 +1,3 @@
-"""
-Ensures simulated metrics are for the iPhone SE or a 38mm watch, which are currently the smallest display profiles.
-"""
-
 from xiblint.rules import Rule
 
 ALLOWED_DEVICES = [
@@ -11,6 +7,10 @@ ALLOWED_DEVICES = [
 
 
 class SimulatedMetricsRetina40(Rule):
+    """
+    Ensures simulated metrics are for the iPhone SE or a 38mm watch
+    which are currently the smallest display profiles.
+    """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         root = context.tree.getroot()
 


### PR DESCRIPTION
Now that we have classes instead of check functions it makes sense to
move the documentation directly to them.