### PR TITLE
Strict font names rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ in the .xib or .storyboard file.
 
   Ensures there are no links to other storyboards in different bundles.
 
+- `strict_font_names`
+
+  Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` in a custom rule configuration using `rules_config` (see below).
+
 ## Usage
 
 For a list of available rules, run `xiblint -h`.
@@ -72,6 +76,14 @@ Place a configuration file named `.xiblint.json` into the root of your source re
       "excluded_rules": [
         "accessibility_*"
       ]
+    },
+    "Modules": {
+      "rules": ["some_rule"],
+      "rules_config": {
+        "some_rule": {
+          "some_rule_specific_option": true
+        }
+      }
     }
   }
 }

--- a/xiblint/rules/strict_font_names.py
+++ b/xiblint/rules/strict_font_names.py
@@ -23,4 +23,4 @@ class StrictFontNames(Rule):
                 continue
 
             if font_name not in allowed_fonts:
-                context.error(element, f'"{font_name}" is not one of the allowed fonts.')
+                context.error(element, '"{}" is not one of the allowed fonts.'.format(font_name))

--- a/xiblint/rules/strict_font_names.py
+++ b/xiblint/rules/strict_font_names.py
@@ -1,0 +1,26 @@
+from xiblint.rules import Rule
+
+
+class StrictFontNames(Rule):
+    """
+    Ensures fonts are in the allowed set.
+
+    Example configuration:
+    {
+      "allowed_fonts": ["ComicSans-Regular", "ComicSans-Bold"],
+      "allow_system_fonts": true
+    }
+    """
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        allowed_fonts = self.config.get('allowed_fonts', [])
+        allow_system_fonts = self.config.get('allow_system_fonts', True)
+
+        for element in context.tree.findall(".//fontDescription") + context.tree.findall(".//font"):
+            font_name = element.get("name")
+            if font_name is None:
+                if not allow_system_fonts:
+                    context.error(element, "Use of system fonts is not allowed.")
+                continue
+
+            if font_name not in allowed_fonts:
+                context.error(element, f'"{font_name}" is not one of the allowed fonts.')

--- a/xiblint/rules/strict_font_names.py
+++ b/xiblint/rules/strict_font_names.py
@@ -13,7 +13,7 @@ class StrictFontNames(Rule):
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         allowed_fonts = self.config.get('allowed_fonts', [])
-        allow_system_fonts = self.config.get('allow_system_fonts', True)
+        allow_system_fonts = self.config.get('allow_system_fonts', False)
 
         for element in context.tree.findall(".//fontDescription") + context.tree.findall(".//font"):
             font_name = element.get("name")


### PR DESCRIPTION
Adds strict font rules. This allows for a configuration like this:

```json
{
  "paths": {
    "Modules": {
      "rules": [
        "strict_font_names"
      ],
      "rules_config": {
        "strict_font_names": {
          "allowed_fonts": [
            "LyftProUI-Bold",
            "LyftProUI-BoldItalic",
            "ProximaNova-Regular",
            "ProximaNova-RegularItalic",
            "ProximaNova-Medium",
            "ProximaNova-MediumItalic",
            "ProximaNova-Bold",
            "ProximaNova-BoldItalic"
          ],
          "allow_system_fonts": false
        }
      }
    }
  }
}
```

It simply compares the name of `<font>` and `<fontDescription>`’s `name` attribute to the allowed list. If the node is missing `name` it is a system font. `<font>` and `<fontDescription>` represent system fonts different, but that doesn't matter for our purposes.