### PR TITLE
Fix flake8 issue:

### DIFF
--- a/xiblint/rules/__init__.py
+++ b/xiblint/rules/__init__.py
@@ -32,4 +32,5 @@ def _collect_checkers():
             raise TypeError("Expected function in {}".format(filepath))
     return _rule_checkers
 
+
 rule_checkers = _collect_checkers()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/lyft/xiblint on Python 3.7.0

$ __flake8 . --count --max-complexity=10 --max-line-length=127 --statistics__
```
./xiblint/rules/__init__.py:35: [E305] expected 2 blank lines after class or function definition, found 1
1     E305 expected 2 blank lines after class or function definition, found 1
1
```