### PR TITLE
Ignore localization comments for `strict_font_names` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ in the .xib or .storyboard file.
 
 - `strict_font_names`
 
-  Ensures all fonts are in an allowed set. Configure `allowed_fonts`, `allow_system_fonts` (default is `true`), and `ignore_localization_comments` (default is `false`) in a custom rule configuration using `rules_config` (see below).
+  Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` (default is `true`) in a custom rule configuration using `rules_config` (see below).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ in the .xib or .storyboard file.
 
 - `strict_font_names`
 
-  Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` in a custom rule configuration using `rules_config` (see below).
+  Ensures all fonts are in an allowed set. Configure `allowed_fonts`, `allow_system_fonts` (default is `true`), and `ignore_localization_comments` (default is `false`) in a custom rule configuration using `rules_config` (see below).
 
 ## Usage
 

--- a/xiblint/rules/strict_font_names.py
+++ b/xiblint/rules/strict_font_names.py
@@ -8,15 +8,22 @@ class StrictFontNames(Rule):
     Example configuration:
     {
       "allowed_fonts": ["ComicSans-Regular", "ComicSans-Bold"],
-      "allow_system_fonts": true
+      "allow_system_fonts": true,
+      "ignore_localization_comments": true
     }
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         allowed_fonts = self.config.get('allowed_fonts', [])
         allow_system_fonts = self.config.get('allow_system_fonts', False)
+        ignore_localization_comments = self.config.get('ignore_localization_comments', True)
 
         for element in context.tree.findall(".//fontDescription") + context.tree.findall(".//font"):
-            font_name = element.get("name")
+            if ignore_localization_comments and element.tag == 'font':
+                container = element.parent.parent.parent
+                if container.tag == 'attributedString' and container.get('key') == 'userComments':
+                    continue
+
+            font_name = element.get('name')
             if font_name is None:
                 if not allow_system_fonts:
                     context.error(element, "Use of system fonts is not allowed.")

--- a/xiblint/rules/strict_font_names.py
+++ b/xiblint/rules/strict_font_names.py
@@ -8,17 +8,16 @@ class StrictFontNames(Rule):
     Example configuration:
     {
       "allowed_fonts": ["ComicSans-Regular", "ComicSans-Bold"],
-      "allow_system_fonts": true,
-      "ignore_localization_comments": true
+      "allow_system_fonts": true
     }
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         allowed_fonts = self.config.get('allowed_fonts', [])
         allow_system_fonts = self.config.get('allow_system_fonts', False)
-        ignore_localization_comments = self.config.get('ignore_localization_comments', True)
 
         for element in context.tree.findall(".//fontDescription") + context.tree.findall(".//font"):
-            if ignore_localization_comments and element.tag == 'font':
+            # Skip <font> tags nested in a localization comment
+            if element.tag == 'font':
                 container = element.parent.parent.parent
                 if container.tag == 'attributedString' and container.get('key') == 'userComments':
                     continue


### PR DESCRIPTION
Hilariously, Interface Builder uses attributed strings for localization comments. This skips fonts in localization comments when running the `strict_font_names` rule.