### PR TITLE
Add `unavailable_system_classes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ in the .xib or .storyboard file.
 
   Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` (default is `true`) in a custom rule configuration using `rules_config` (see below).
 
+- `strict_customization`
+
+  Ensures a system type uses a set of custom clases. Configure `custom_classes` in a custom rule configuration using `rules_config` (see below).
+
 ## Usage
 
 For a list of available rules, run `xiblint -h`.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ in the .xib or .storyboard file.
 
   Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` (default is `true`) in a custom rule configuration using `rules_config` (see below).
 
-- `strict_customization`
+- `unavailable_system_classes`
 
-  Ensures a system type uses a set of custom clases. Configure `custom_classes` in a custom rule configuration using `rules_config` (see below).
+  Ensures a system type uses a set of custom clases. Configure `system_classes` in a custom rule configuration using `rules_config` (see below).
 
 ## Usage
 

--- a/xiblint/rules/strict_customization.py
+++ b/xiblint/rules/strict_customization.py
@@ -26,11 +26,13 @@ class StrictCustomization(Rule):
                     if self.is_valid(element, options):
                         continue
 
-                    context.error(element, '`<' + tag_name + '>` must use `' + '`, `'.join(options) + '` instead of `' + element.get('customModule') + '.' + element.get('customClass') + '`.')
+                    context.error(element, '`<' + tag_name + '>` must use `' + '`, `'.join(options) + '` instead of `'
+                                  + element.get('customModule') + '.' + element.get('customClass') + '`.')
                     return
 
-                context.error(element, '`<' + tag_name + '>` without a custom class is prohibited. Use `' + '`, `'.join(options) + '` instead.')
+                context.error(element, '`<' + tag_name + '>` without a custom class is prohibited. Use `' + '`, `'
+                              .join(options) + '` instead.')
 
-    def is_valid(self, element, custom_classes): # type: (Rule, Element, [str]) -> Bool
+    def is_valid(self, element, custom_classes):  # type: (Rule, Element, [str]) -> Bool
         full_name = element.get('customModule') + '.' + element.get('customClass')
         return full_name in custom_classes

--- a/xiblint/rules/strict_customization.py
+++ b/xiblint/rules/strict_customization.py
@@ -1,0 +1,36 @@
+from xiblint.rules import Rule
+
+
+class StrictCustomization(Rule):
+    """
+    Ensures given system types are subclassed by a set of classes.
+
+    You must specify a module as part of the class name.
+
+    Example configuration:
+    {
+      "custom_classes": {
+          "navigationController": ["ModuleName.CustomNavigationController"],
+          "button": ["ModuleName.CoolButton", "ModuleName.CoolerButton"]
+      }
+    }
+    """
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        custom_classes = self.config.get('custom_classes', {})
+        for tag_name in custom_classes.keys():
+            for element in context.tree.findall('.//' + tag_name):
+                custom_class = element.get('customClass')
+                options = custom_classes.get(tag_name)
+
+                if custom_class:
+                    if self.is_valid(element, options):
+                        continue
+
+                    context.error(element, '`<' + tag_name + '>` must use `' + '`, `'.join(options) + '` instead of `' + element.get('customModule') + '.' + element.get('customClass') + '`.')
+                    return
+
+                context.error(element, '`<' + tag_name + '>` without a custom class is prohibited. Use `' + '`, `'.join(options) + '` instead.')
+
+    def is_valid(self, element, custom_classes): # type: (Rule, Element, [str]) -> Bool
+        full_name = element.get('customModule') + '.' + element.get('customClass')
+        return full_name in custom_classes

--- a/xiblint/rules/unavailable_system_classes.py
+++ b/xiblint/rules/unavailable_system_classes.py
@@ -1,7 +1,7 @@
 from xiblint.rules import Rule
 
 
-class StrictCustomization(Rule):
+class UnavailableSystemClasses(Rule):
     """
     Ensures given system types are subclassed by a set of classes.
 
@@ -9,14 +9,14 @@ class StrictCustomization(Rule):
 
     Example configuration:
     {
-      "custom_classes": {
+      "system_classes": {
           "navigationController": ["ModuleName.CustomNavigationController"],
           "button": ["ModuleName.CoolButton", "ModuleName.CoolerButton"]
       }
     }
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
-        custom_classes = self.config.get('custom_classes', {})
+        custom_classes = self.config.get('system_classes', {})
 
         for tag_name in custom_classes.keys():
             for element in context.tree.findall('.//{}'.format(tag_name)):


### PR DESCRIPTION
This adds the `unavailable_system_classes` rule. This ensures that a given tag (i.e. `<button>`, `<viewController>`, etc.) has one of the specified custom classes.

With the following configuration:

```json
{
  "rules": [
    "unavailable_system_classes"
  ],
  "rules_config": {
    "unavailable_system_classes": {
      "system_classes": {
        "navigationController": ["CoreUI.NavigationController"]
      }
    }
}
```

This has the following redacted output on the Lyft project:

```
Car.storyboard:248: error: E8E-bb-ZGv: `<navigationController>` must use `CoreUI.NavigationController` instead of `LyftUI.NavigationController`. [rule: strict_customization]
Map.storyboard:658: error: TXt-Ri-g2P: `<navigationController>` must use `CoreUI.NavigationController` instead of `LyftUI.NavigationController`. [rule: strict_customization]
Passenger.storyboard:372: error: 9wW-6l-rv8: `<navigationController>` without a custom class is prohibited. Use `CoreUI.NavigationController` instead. [rule: strict_customization]
Driver.storyboard:1336: error: Zpe-RA-erm: `<navigationController>` must use `CoreUI.NavigationController` instead of `LyftUI.NavigationController`. [rule: strict_customization]
```