### PR TITLE
Add `unavailable_custom_classes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ in the .xib or .storyboard file.
 
   Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` (default is `true`) in a custom rule configuration using `rules_config` (see below).
 
-- `unavailable_classes`
+- `unavailable_custom_classes`
 
   Prevent a list of classes from appearing as custom classes. Configure `custom_classes` in a custom rule configuration using `rules_config` (see below). This is a mapping of the full name of the class (`ModuleName.ClassName`) to the suggested replacement.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ in the .xib or .storyboard file.
 
   Ensures all fonts are in an allowed set. Configure `allowed_fonts` and `allow_system_fonts` (default is `true`) in a custom rule configuration using `rules_config` (see below).
 
+- `unavailable_classes`
+
+  Prevent a list of classes from appearing as custom classes. Configure `custom_classes` in a custom rule configuration using `rules_config` (see below). This is a mapping of the full name of the class (`ModuleName.ClassName`) to the suggested replacement.
+
 ## Usage
 
 For a list of available rules, run `xiblint -h`.

--- a/xiblint/rules/unavailable_classes.py
+++ b/xiblint/rules/unavailable_classes.py
@@ -1,0 +1,32 @@
+from xiblint.rules import Rule
+
+
+class UnavailableClasses(Rule):
+    """
+    Ensures a given custom class isn't used system types are subclassed by a set of classes.
+
+    You must specify a module as part of the class name.
+
+    Example configuration:
+    {
+      "classes": {
+          "SomeModule.LegacyButton": "SomeModule.NewButton"
+      }
+    }
+    """
+    def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
+        unavailable_classes = self.config.get('classes', {})
+        if not unavailable_classes:
+            return
+
+        for element in context.tree.findall('.//*[@customClass]'):
+            full_name = self._full_class_name(element)
+            replacement = unavailable_classes.get(full_name)
+
+            if not replacement:
+                continue
+
+            context.error(element, '`{}` is prohibited. Use `{}` instead.'.format(full_name, replacement))
+
+    def _full_class_name(self, element):  # type: (Rule, Element) -> str
+        return "{}.{}".format(element.get('customModule'), element.get('customClass'))

--- a/xiblint/rules/unavailable_custom_classes.py
+++ b/xiblint/rules/unavailable_custom_classes.py
@@ -1,21 +1,21 @@
 from xiblint.rules import Rule
 
 
-class UnavailableClasses(Rule):
+class UnavailableCustomClasses(Rule):
     """
-    Ensures a given custom class isn't used system types are subclassed by a set of classes.
+    Ensures a given custom class isn't used and provides a replacement suggestion.
 
     You must specify a module as part of the class name.
 
     Example configuration:
     {
-      "classes": {
+      "custom_classes": {
           "SomeModule.LegacyButton": "SomeModule.NewButton"
       }
     }
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
-        unavailable_classes = self.config.get('classes', {})
+        unavailable_classes = self.config.get('custom_classes', {})
         if not unavailable_classes:
             return
 

--- a/xiblint/rules/unavailable_custom_classes.py
+++ b/xiblint/rules/unavailable_custom_classes.py
@@ -16,8 +16,6 @@ class UnavailableCustomClasses(Rule):
     """
     def check(self, context):  # type: (Rule, xiblint.xibcontext.XibContext) -> None
         unavailable_classes = self.config.get('custom_classes', {})
-        if not unavailable_classes:
-            return
 
         for element in context.tree.findall('.//*[@customClass]'):
             full_name = self._full_class_name(element)


### PR DESCRIPTION
This adds the `unavailable_custom_classes` rule. This prevents a black list of custom classes from appearing in IB files and suggests a replacement when one is found.

With the following configuration:

```json
{
  "rules": [
    "unavailable_custom_classes"
  ],
  "rules_config": {
    "unavailable_custom_classes": {
      "classes": {
          "CoreUI.Button": "CoreUI.ButtonProxy",
          "CoreUI.Checkbox": "CoreUI.CheckboxProxy",
          "CoreUI.CircularButton": "CoreUI.CircularButtonProxy",
          "CoreUI.HorizontalDivider": "CoreUI.HorizontalDividerProxy",
          "CoreUI.RadioButton": "CoreUI.RadioButtonProxy",
          "CoreUI.SpinningLoader": "CoreUI.SpinningLoaderProxy",
          "CoreUI.Switch": "CoreUI.SwitchProxy",
          "CoreUI.ToggleButton": "CoreUI.ToggleButtonProxy"
    }
}
```

This has the following redacted output on the Lyft project:

```
Onboarding.xib:52: error: t36-t1-ftS: `CoreUI.CircularButton` is prohibited. Use `CoreUI.CircularButtonProxy` instead. [rule: unavailable_classes]
```