### PR TITLE
Fix unavailable_system_classes

### DIFF
--- a/xiblint/rules/unavailable_system_classes.py
+++ b/xiblint/rules/unavailable_system_classes.py
@@ -31,7 +31,7 @@ class UnavailableSystemClasses(Rule):
                     continue
 
                 full_class_name = self._full_class_name(element)
-                if full_class_name in custom_classes:
+                if full_class_name in options:
                     continue
 
                 context.error(element, '`<{}>` must use `{}` instead of `{}`.'


### PR DESCRIPTION
Previously this would say an allowed classes was also not allowed. This corrects the issue by searching in the appropriate array.