### PR TITLE
Named colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ in the .xib or .storyboard file.
   Checks for labels with outlets into a view controller that have no accessibility identifiers.
   Labels with outlets might get dynamic text, and therefore should be accessible to UI testing.
 
+- `named_colors`
+
+  Ensures all colors are using named colors from an asset catalog. Configure `ignore_alpha` (default is `false`) in a custom rule configuration using `rules_config` (see below) if you’d like to ignore colors with alpha.
+
 - `no_trait_variations`
 
   Ensures Trait Variations are disabled.

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -25,7 +25,7 @@ class NamedColors(Rule):
                 continue
 
             # Skip colors with alpha (if configured)
-            if ignore_alpha and element.get('alpha') != "1":
+            if ignore_alpha and element.get('alpha') != '1':
                 continue
 
             # Require a name

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -1,0 +1,33 @@
+from xiblint.rules import Rule
+from xiblint.xibcontext import XibContext
+
+
+class NamedColors(Rule):
+    """
+    Ensures colors are using named colors from an asset catalog.
+
+    Example configuration:
+    {
+      "ignore_alpha": true
+    }
+    """
+    def check(self, context):  # type: (XibContext) -> None
+        ignore_alpha = self.config.get('ignore_alpha', False)
+
+        for element in context.tree.findall(".//color"):
+            # Skip <color> tags nested in a localization comment
+            container = element.parent.parent.parent
+            if container.tag == 'attributedString' and container.get('key') == 'userComments':
+                continue
+
+            # Skip <color> tags part of a color definition
+            if element.parent.tag == 'namedColor':
+                continue
+
+            # Skip colors with alpha
+            if ignore_alpha and element.get('alpha') is not None:
+                continue
+
+            if element.get('name') is None:
+                context.error(element, "Use of custom colors is not allowed. Use a named color instead.")
+                continue

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -30,10 +30,10 @@ class NamedColors(Rule):
 
             # Require a name
             if element.get('name') is None:
-                context.error(element, "Use of custom colors is not allowed. Use a named color from an asset catalog instead.")
+                context.error(element, "Use of custom colors is not allowed. Use a named color instead.")
                 continue
 
             # If `catalog` is present, it's a named system color
             if element.get('catalog') is not None:
-                context.error(element, "Use of named system colors is not allowed. Use a named color from an asset catalog instead.")
+                context.error(element, "Use of named system colors is not allowed. Use a named color instead.")
                 continue

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -24,10 +24,16 @@ class NamedColors(Rule):
             if element.parent.tag == 'namedColor':
                 continue
 
-            # Skip colors with alpha
-            if ignore_alpha and element.get('alpha') is not None:
+            # Skip colors with alpha (if configured)
+            if ignore_alpha and element.get('alpha') != "1":
                 continue
 
+            # Require a name
             if element.get('name') is None:
-                context.error(element, "Use of custom colors is not allowed. Use a named color instead.")
+                context.error(element, "Use of custom colors is not allowed. Use a named color from an asset catalog instead.")
+                continue
+
+            # If `catalog` is present, it's a named system color
+            if element.get('catalog') is not None:
+                context.error(element, "Use of named system colors is not allowed. Use a named color from an asset catalog instead.")
                 continue


### PR DESCRIPTION
Add a new rule to required named colors with an option to ignore colors that aren’t opaque.