### PR TITLE
Feature/allow clear color

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ in the .xib or .storyboard file.
 
 - `named_colors`
 
-  Ensures all colors are using named colors from an asset catalog. Configure `allowed_colors` to limit the colors to a subset (default is all named colors are allowed), `allow_system_colors` (default is `false`) and `ignore_alpha` (default is `false`) in a custom rule configuration using `rules_config` (see below).
+  Ensures all colors are using named colors from an asset catalog. Configure `allowed_colors` to limit the colors to a subset (default is all named colors are allowed), `allow_system_colors` (default is `false`), `allow_clear_color` (default is `false`) and `ignore_alpha` (default is `false`) in a custom rule configuration using `rules_config` (see below).
 
 - `no_trait_variations`
 

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -63,6 +63,7 @@ class NamedColors(Rule):
                 continue
 
             # If allowed_colors is set, verify that color_name is included
+            options_string = '`, `'.join(map(str, allowed_colors))
             if allowed_colors and color_name not in allowed_colors:
-                context.error(element, '"{}" is not one of the allowed colors: "{}".'
-                              .format(color_name, allowed_colors))
+                context.error(element, '"{}" is not one of the allowed colors: `{}`.'
+                              .format(color_name, options_string))

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -26,12 +26,8 @@ class NamedColors(Rule):
             if container.tag == 'attributedString' and container.get('key') == 'userComments':
                 continue
 
-            # Skip <color> tags part of a color definition
-            if element.parent.tag == 'namedColor':
-                continue
-
-            # Skip <color> tags part of a system color definition
-            if element.parent.tag == 'systemColor':
+            # Skip <color> tags part of a color or system color definition
+            if element.parent.tag == 'namedColor' or element.parent.tag == 'systemColor':
                 continue
 
             # Skip colors with alpha (if configured)

--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -10,13 +10,15 @@ class NamedColors(Rule):
     {
       "allowed_colors": ["CustomRed", "CustomGreen"],
       "allow_system_colors": true,
-      "ignore_alpha": true
+      "ignore_alpha": true,
+      "allow_clear_color": true
     }
     """
     def check(self, context):  # type: (XibContext) -> None
         allowed_colors = self.config.get('allowed_colors', [])
         allow_system_colors = self.config.get('allow_system_colors', False)
         ignore_alpha = self.config.get('ignore_alpha', False)
+        allow_clear_color = self.config.get('allow_clear_color', False)
 
         for element in context.tree.findall(".//color"):
             # Skip <color> tags nested in a localization comment
@@ -34,6 +36,14 @@ class NamedColors(Rule):
 
             # Skip colors with alpha (if configured)
             if ignore_alpha and element.get('alpha') is not None and element.get('alpha') != '1':
+                continue
+
+            # Skip clear color (if configured)
+            if (
+                    allow_clear_color and
+                    element.get('alpha') is not None and element.get('white') is not None and
+                    element.get('alpha') == '0.0' and element.get('white') == '0.0'
+            ):
                 continue
 
             # If `systemColor` or `catalog` is present, it's a named system color


### PR DESCRIPTION
Added a new flag to named_colors to allow the use of clear colors. This is useful when "ignore_alpha" is too permissive.

Also changed the format of the error message for "allowed_colors" which were printed with the unicode (u') prefix.