### PR TITLE
feature: specify the color property (e.g. textColor, tintColor) that is causing the named_colors warning.

### DIFF
--- a/xiblint/rules/named_colors.py
+++ b/xiblint/rules/named_colors.py
@@ -42,6 +42,8 @@ class NamedColors(Rule):
             ):
                 continue
 
+            color = element.get('key') if element.get('key') else 'color'
+
             # If `systemColor` or `catalog` is present, it's a named system color
             if (
                     element.get('systemColor') is not None or
@@ -49,17 +51,21 @@ class NamedColors(Rule):
                     element.get('catalog') is not None
             ):
                 if not allow_system_colors:
-                    context.error(element, "Use of named system colors is not allowed. Use a named color instead.")
+                    context.error(element, 
+                                  "Use of named system {}s is not allowed. Use a named color instead."
+                                  .format(color))
                 continue
 
             # Require a name
             color_name = element.get('name')
             if color_name is None:
-                context.error(element, "Use of custom colors is not allowed. Use a named color instead.")
+                context.error(element, 
+                              "Use of custom {}s is not allowed. Use a named color instead."
+                              .format(color))
                 continue
 
             # If allowed_colors is set, verify that color_name is included
             options_string = '`, `'.join(map(str, allowed_colors))
             if allowed_colors and color_name not in allowed_colors:
-                context.error(element, '"{}" is not one of the allowed colors: `{}`.'
-                              .format(color_name, options_string))
+                context.error(element, '"{}" is not one of the allowed {}s: `{}`.'
+                              .format(color_name, color, options_string))


### PR DESCRIPTION
Added the specific color property that is causing the warning in the error message.

```
Use of custom textColors is not allowed. Use a named color instead. [rule: named_colors]
Use of custom tintColors is not allowed. Use a named color instead. [rule: named_colors]
Use of custom backgroundColors is not allowed. Use a named color instead. [rule: named_colors]

"foo" is not one of the allowed backgroundColors: `bar`,`baz`. [rule: named_colors]
```

This way when the developer uses the `object_id` to find the problematic object, they don't need to look at the xml to know which color property (e.g backgroundColor, textColor, tintColor) to modify.